### PR TITLE
Allows to grant access to repos using file patterns

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This is just an example how to backup all repositorie under $HOME/repositories
+# to other host. This should be run as a git user. You should allow git user
+# to access git@backup-host and allow git@backup-host to access your repositories.
+# (ie. you should add public key git@backup-host.pub to gitosis-admin/keydir and
+# add to gitosis.conf something like this:
+#   [group buckap]
+#   members = git@backup-host
+#   readable = *
+# )
+
+backup_service=git@backup-host
+
+pushd $HOME/repositories
+for repo in *.git;
+do
+	if ssh git@backup-host test -e repositories/$repo;
+	then
+		cd repositories/$repo
+		git push --mirror git@backup-host:repositories/$repo
+	else
+		ssh git@backup-host git clone --mirror git@atlantis:$repo repositories/$repo 
+	fi
+done
+popd

--- a/example.conf
+++ b/example.conf
@@ -34,6 +34,18 @@ members = alice bill
 map writable visiblename1 = actualname1
 map readonly visiblename2 = actualname2
 
+## You can allow your admins to write to all repositories under foo/ 
+## (and allow them to create new one)
+[group admins]
+members = john ann
+writable = foo/*
+
+## You can also grant read access to all repositories to your backup 
+## service (see buckup.sh)
+[group backup]
+memebers = git@buckup-host
+readable = *
+
 [repo foo]
 ## Allow gitweb to show this repository.
 gitweb = yes

--- a/gitosis/access.py
+++ b/gitosis/access.py
@@ -1,4 +1,5 @@
 import os, logging
+import fnmatch
 from ConfigParser import NoSectionError, NoOptionError
 
 from gitosis import group
@@ -43,16 +44,17 @@ def haveAccess(config, user, mode, path):
 
         mapping = None
 
-        if path in repos:
-            log.debug(
-                'Access ok for %(user)r as %(mode)r on %(path)r'
-                % dict(
-                user=user,
-                mode=mode,
-                path=path,
-                ))
-            mapping = path
-        else:
+        for rep in repos:
+            if fnmatch.fnmatch(path, rep):
+                log.debug(
+                    'Access ok for %(user)r as %(mode)r on %(path)r'
+                    % dict(
+                    user=user,
+                    mode=mode,
+                    path=path,
+                    ))
+                mapping = path
+        if not mapping:
             try:
                 mapping = config.get('group %s' % groupname,
                                      'map %s %s' % (mode, path))

--- a/gitosis/test/test_access.py
+++ b/gitosis/test/test_access.py
@@ -148,3 +148,15 @@ def test_dotgit():
     cfg.set('group fooers', 'writable', 'foo/bar')
     eq(access.haveAccess(config=cfg, user='jdoe', mode='writable', path='foo/bar.git'),
        ('repositories', 'foo/bar'))
+
+def test_patterns():
+    cfg = RawConfigParser()
+    cfg.add_section('group fooers')
+    cfg.set('group fooers', 'members', 'jdoe')
+    cfg.set('group fooers', 'writable', 'foo/bar/*')
+    eq(access.haveAccess(config=cfg, user='jdoe', mode='writable', path='foo/bar/baz.git'),
+       ('repositories', 'foo/bar/baz'))
+    eq(access.haveAccess(config=cfg, user='jdoe', mode='writable', path='foo/bar.git'),
+       None)
+    eq(access.haveAccess(config=cfg, user='jdoe', mode='writable', path='foo/barbaz.git'),
+       None)


### PR DESCRIPTION
This is not ready yet - I need to do tests in real installation (but the code is ready for review). Let me know what you think (if this is a right direction) and if you are interested to merge this.

From example.conf:

```
## You can allow your admins to write to all repositories under foo/ 
## (and allow them to create new one)
[group admins]
members = john ann
writable = foo/*

## You can also grant read access to all repositories to your backup 
## service (see buckup.sh)
[group backup]
memebers = git@buckup-host
readable = *
```
