### PR TITLE
Fix: assert == '.git' error

### DIFF
--- a/gitosis/gitdaemon.py
+++ b/gitosis/gitdaemon.py
@@ -66,6 +66,8 @@ def set_export_ok(config):
         to_recurse = []
         repos = []
         for dirname in dirnames:
+            if dirname == '.git':
+                continue
             if dirname.endswith('.git'):
                 repos.append(dirname)
             else:


### PR DESCRIPTION
If the '.git' is somewhere in the directories, even it is not configured
in gitosis config, when it walks through all directory names, it will
emit this assert error. The reason is that 'os.path.splitext(repo)' does
not work as expected, as it returns '.git' and '' for the input '.git'.